### PR TITLE
Restart the dev-server.

### DIFF
--- a/bintray
+++ b/bintray
@@ -10,6 +10,7 @@ if [ "x$TRAVIS_BRANCH" == "xmaster" ] && [ "x$TRAVIS_PULL_REQUEST" == "xfalse" ]
 	curl -X DELETE $API_AUTH $API_URL/packages/nsg/craft/craft-server/versions/dev
 	curl -T $ARTIFACT $API_AUTH $API_URL/content/nsg/craft/craft-server/dev/craft-server-build-dev.jar
 	curl -X POST -unsg:$bintray_api_key $API_URL/content/nsg/craft/craft-server/dev/publish
+	echo | nc craft.nsg.cc 44711
 fi
 
 # Upload tagged releases to bintray


### PR DESCRIPTION
Everything written to port 44711 will:

* Shut down the running dev server
* Download the latest dev build from bintray
* Start the server

Just a quick easy hack :) I will add a secret string to restart it in the future if the need arises.

FYI, the script is called `start` and is running inside a tmux session.